### PR TITLE
Fix contentSize calculation bug

### DIFF
--- a/FullyHorizontalCollectionView/FullyHorizontalFlowLayout.m
+++ b/FullyHorizontalCollectionView/FullyHorizontalFlowLayout.m
@@ -69,9 +69,9 @@
     CGSize size = [super collectionViewContentSize];
     
     CGFloat collectionViewWidth = self.collectionView.frame.size.width;
-    NSInteger nbOfScreens = (int)(size.width / collectionViewWidth);
+    NSInteger nbOfScreens = (int)ceil((size.width / collectionViewWidth));
     
-    CGSize newSize = CGSizeMake((nbOfScreens+1) * collectionViewWidth, size.height);
+    CGSize newSize = CGSizeMake((nbOfScreens) * collectionViewWidth, size.height);
     
     return newSize;
 }


### PR DESCRIPTION
Original calculation will result in 2 page when there is only 1 page. If `sizeWidth == collectionViewWidth` then your new size will be `1 + 1 * collectionViewWidth`
